### PR TITLE
feat(user): add role, isActive, subscriptionStatus fields

### DIFF
--- a/migrations/20250718165324-add-fields-to-user-table.js
+++ b/migrations/20250718165324-add-fields-to-user-table.js
@@ -1,0 +1,50 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("Users", "role", {
+      type: Sequelize.ENUM("user", "admin"),
+      defaultValue: "user",
+      allowNull: false,
+    });
+
+    await queryInterface.addColumn("Users", "isActive", {
+      type: Sequelize.BOOLEAN,
+      defaultValue: true,
+      allowNull: false,
+    });
+    await queryInterface.addColumn("Users", "bio", {
+      type: Sequelize.TEXT,
+    });
+    await queryInterface.addColumn("Users", "subscriptionStatus", {
+      type: Sequelize.ENUM("free", "premium", "trial"),
+      defaultValue: "trial",
+      allowNull: false,
+    });
+    await queryInterface.addColumn("Users", "phone", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn("Users", "address", {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("Users", "role");
+    await queryInterface.removeColumn("Users", "bio");
+    await queryInterface.removeColumn("Users", "isactive");
+    await queryInterface.removeColumn("Users", "phone");
+    await queryInterface.removeColumn("Users", "address");
+    await queryInterface.removeColumn("Users", "subscriptionStatus");
+
+    await queryInterface.sequelize.query(
+      'DROP TYPE IF EXISTS "enum_Users_role";'
+    );
+    await queryInterface.sequelize.query(
+      'DROP TYPE IF EXISTS "enum_Users_subscriptionStatus";'
+    );
+  },
+};

--- a/models/user.js
+++ b/models/user.js
@@ -34,6 +34,33 @@ const User = sequelize.define(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    address: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    bio: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    role: {
+      type: DataTypes.ENUM("user", "admin"),
+      allowNull: false,
+      defaultValue: "user",
+    },
+    isActive: {
+      type: DataTypes.BOOLEAN,
+      default: true,
+      allowNull: false,
+    },
+    subscriptionStatus: {
+      type: DataTypes.ENUM("free", "premium", "trial"),
+      defaultValue: "trial",
+      allowNull: false,
+    },
+    phone: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
     createdAt: {
       type: DataTypes.DATE,
       defaultValue: DataTypes.NOW,


### PR DESCRIPTION
- Added new fields to the User model:
  - `role`: Defines user role (e.g., user/admin) for access control.
  - `isActive`: Indicates whether a user account is active or deactivated.
  - `subscriptionStatus`: Tracks user's plan (free, premium, trial).
  - `address`, `phone`, and `bio`: Enhances the user profile with optional personal info.

- Updated the Sequelize User model and generated a corresponding migration to reflect these changes in the database.

These additions support improved profile customization, role-based access, and subscription management for future feature expansion.
