### PR TITLE
feat: fetch expense details using expenseId with relations

### DIFF
--- a/controllers/expense/index.js
+++ b/controllers/expense/index.js
@@ -14,12 +14,12 @@ const ExpenseController = {
       return errorResponse(res, 500, error);
     }
   },
-  getExpenses: async (req, res) => {
+  getAllExpenses: async (req, res) => {
     const userId = req.user.id;
     const { categoryId, paymentMethodId, month, year, q, limit, page } =
       req.query;
     try {
-      const data = await ExpenseService.getExpenseService(userId, {
+      const data = await ExpenseService.getAllExpensesService(userId, {
         categoryId,
         paymentMethodId,
         month,
@@ -33,6 +33,22 @@ const ExpenseController = {
       return errorResponse(res, 400, error.message || "Something went wrong.");
     }
   },
+  getExpenseById: async (req, res) => {
+    const { expenseId } = req.params;
+    if (!expenseId) {
+      return errorResponse(res, 400, "Expense ID is required");
+    }
+    try {
+      const expense = await ExpenseService.getExpenseByIdService(expenseId);
+      if (!expense) {
+        return errorResponse(res, 404, "Expense not found");
+      }
+      return successResponse(res, 200, "Expense fetched successfully", expense);
+    } catch (error) {
+      return errorResponse(res, 500, error?.message || "Internal Server Error");
+    }
+  },
+
   getExpenseSummary: async (req, res) => {
     const userId = req.query.userId;
     try {
@@ -65,7 +81,7 @@ const ExpenseController = {
       return successResponse(res, 200, "Expense deleted successfully");
     } catch (error) {}
   },
-  uploadExpeneAttachments: async (req, res) => {
+  uploadExpenseAttachments: async (req, res) => {
     const files = req.files;
     const userId = req.user.id;
     const expenseId = req.body.expenseId;

--- a/routes/v1Routes/expense.js
+++ b/routes/v1Routes/expense.js
@@ -1,10 +1,9 @@
 const express = require("express");
+const multer = require("multer");
 const ExpenseController = require("../../controllers/expense");
 
-const multer = require("multer");
-
-const upload = multer({ dest: "uploads/" });
 const router = express.Router();
+const upload = multer({ dest: "uploads/" });
 
 router.post("/", ExpenseController.createExpense);
 router.patch("/:id", ExpenseController.editExpense);
@@ -12,12 +11,13 @@ router.delete("/:id", ExpenseController.deleteExpense);
 
 router.get("/expense-summary", ExpenseController.getExpenseSummary);
 
-router.get("/", ExpenseController.getExpenses);
+router.get("/", ExpenseController.getAllExpenses);
+router.get("/:expenseId", ExpenseController.getExpenseById);
 
 router.post(
   "/upload-attachments",
   upload.array("files", 5),
-  ExpenseController.uploadExpeneAttachments
+  ExpenseController.uploadExpenseAttachments
 );
 
 module.exports = router;

--- a/services/expense.service.js
+++ b/services/expense.service.js
@@ -17,7 +17,7 @@ const ExpenseService = {
     }
   },
 
-  getExpenseService: async (userId, filters) => {
+  getAllExpensesService: async (userId, filters) => {
     const { month, year, limit, page } = filters;
     const offset = page * limit;
     try {
@@ -59,6 +59,7 @@ const ExpenseService = {
         include: [
           { model: Category, attributes: ["id", "name"] },
           { model: PaymentMethods, attributes: ["id", "name"] },
+          { model: ExpenseAttachment, as: "attachments" },
         ],
         limit: Number(limit),
         offset: Number(offset),
@@ -71,6 +72,26 @@ const ExpenseService = {
         resp: rows,
       };
       return data;
+    } catch (error) {
+      throw handleSequelizeError(error);
+    }
+  },
+  getExpenseByIdService: async (expenseId) => {
+    try {
+      const resp = await Expense.findOne({
+        where: {
+          id: expenseId,
+        },
+        include: [
+          { model: Category, attributes: ["id", "name"] },
+          { model: PaymentMethods, attributes: ["id", "name"] },
+          { model: ExpenseAttachment, as: "attachments" },
+        ],
+      });
+      if (!resp) {
+        throw new Error("Expense Not Found");
+      }
+      return resp;
     } catch (error) {
       throw handleSequelizeError(error);
     }


### PR DESCRIPTION
Added  the logic for fetching an expense by `expenseId` via the `GET /expenses/:expenseId` API. Refactored:

* Controller to correctly validate and fetch using `expenseId`.
* Service layer to use `expenseId` instead of generic `id`.
* Frontend hook (`useGetExpenseById`) to use `GET` instead of `POST`.

**Testing Ideas:**

1. **Positive Case:**

   * Call `GET /expenses/123` with a valid `expenseId` → should return full expense details including category, payment method, and attachments.

2. **Negative Case:**

   * Call with invalid ID → should return "Expense Not Found".
   * Call with missing `expenseId` → should return `400 Bad Request`.

3. **Frontend Testing:**

   * Use `useGetExpenseById(expenseId)` and ensure UI renders correct data or shows fallback/error states accordingly.

